### PR TITLE
Improve bundling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ matrix:
     - python: 3.6
       env: TOX_ENV=docs
     - python: 3.6
+      env: TOX_ENV=manifest
+    - python: 3.6
       env: TOX_ENV=pep8
 
 install: pip install tox

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,12 +1,15 @@
-include AUTHORS.rst
-include LICENSE
-include README.rst
+include LICENSE *.rst
 
-recursive-include docs Makefile *.py *.rst
-
+# Tests
+include tox.ini .coveragerc conftest.py *-requirements.txt
+recursive-include tests *.py
 exclude .coveragerc
 exclude .travis.yml
-exclude tox.ini
 
+# Documentation
+include docs/Makefile docs/docutils.conf
+recursive-include docs *.png
+recursive-include docs *.svg
+recursive-include docs *.py
+recursive-include docs *.rst
 prune docs/_build
-prune tests

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,13 +3,11 @@ include LICENSE *.rst
 # Tests
 include tox.ini .coveragerc conftest.py *-requirements.txt
 recursive-include tests *.py
-exclude .coveragerc
 exclude .travis.yml
 
 # Documentation
-include docs/Makefile docs/docutils.conf
+include docs/Makefile
 recursive-include docs *.png
-recursive-include docs *.svg
 recursive-include docs *.py
 recursive-include docs *.rst
 prune docs/_build

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,5 @@
 [flake8]
 ignore = D105
+
+[metadata]
+license_file = LICENSE

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = docs,pep8,py34,py35,py36
+envlist = docs,manifest,pep8,py34,py35,py36
 
 [testenv]
 deps =
@@ -18,6 +18,12 @@ deps = -rdocs-requirements.txt
 commands =
     sphinx-build -W -b html -d {envtmpdir}/doctrees docs docs/_build/html
     doc8 --allow-long-titles README.rst docs/ --ignore-path docs/_build/
+
+[testenv:manifest]
+basepython = python3.6
+deps = check-manifest
+skip_install = true
+commands = check-manifest
 
 [testenv:pep8]
 basepython = python3.6


### PR DESCRIPTION
This patch introduces check-manifest to ensure that `MANIFEST.in` is
kept up-to-date with the package. Changes are being made to the manifest
file based on its output as well as some good advice.

The tests will now be included in bundles, as well as the static
asset(s) required to build the documentation. The license file will be
included in wheels.