### PR TITLE
Add a tox job to do a release

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -33,3 +33,12 @@ deps =
     pydocstyle<2.0.0
 commands =
     flake8 doozer
+
+[testenv:release]
+basepython = python3.6
+deps =
+    twine
+    wheel
+commands =
+    python setup.py sdist bdist_wheel
+    twine upload --sign --skip-existing {posargs} dist/*


### PR DESCRIPTION
By placing this inside tox, no one has to remember the specific command
or dependencies used to perform a release.

Signed-off-by: Andy Dirnberger <andy@dirnberger.me>