### PR TITLE
Remove old version directives

### DIFF
--- a/doozer/cli.py
+++ b/doozer/cli.py
@@ -48,8 +48,6 @@ def register_commands(namespace, functions, namespace_kwargs=None,
         This function is a wrapper around
         :func:`~argh.assembling.add_commands`. Please refer to its
         documentation for any arguments not explained here.
-
-    .. versionadded:: 1.1.0
     """
     commands = []
 

--- a/doozer/contrib/sphinx/__init__.py
+++ b/doozer/contrib/sphinx/__init__.py
@@ -22,8 +22,6 @@ class DoozerCLIDirective(AutoprogramDirective):
         .. doozercli:: doozer_database:Database
            :start_command: db
 
-    .. versionadded:: 1.1.0
-
     .. versionchanged:: 1.2.0
 
         The ``prog`` option will default to the proper way to invoke


### PR DESCRIPTION
Once a version is no longer supported, we want to remove the version
directives from docstrings. I probably should have done this as part of
9681f3c.