### PR TITLE
Add type annotations

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Version 2.0.0
 Release TBD
 
 - Drop support for Python 3.4 and 3.5 *(backwards incompatible)*
+- Add type annotations
 
 Version 1.2.0
 -------------

--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -1,4 +1,5 @@
 doc8
 sphinx>=1.3
+sphinx-autodoc-typehints
 sphinx_rtd_theme
 sphinxcontrib-autoprogram

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -38,6 +38,7 @@ extensions = [
     'sphinx.ext.todo',
     'sphinx.ext.viewcode',
     'doozer.contrib.sphinx',
+    'sphinx_autodoc_typehints',
     'sphinxcontrib.autoprogram',
 ]
 

--- a/doozer/base.py
+++ b/doozer/base.py
@@ -1,14 +1,20 @@
 """Implementation of the service."""
 
 import asyncio
+from asyncio import AbstractEventLoop, Future, Queue
 from contextlib import suppress
 from copy import deepcopy
 import logging
 import sys
 import traceback
+from typing import Any, Dict, Iterable, List, NoReturn, Optional
 
+# doozer.extensions.Extension is needed for a forward reference in an
+# annotation.
+from . import extensions  # NOQA: F401
 from .config import Config
 from .exceptions import Abort
+from .types import Callback, Consumer, Message
 
 __all__ = ('Application',)
 
@@ -20,21 +26,27 @@ class Application:
     callback.
 
     Args:
-        name (str): The name of the application.
-        settings (Optional[object]): An object with attributed-based
-            settings.
-        consumer (optional): Any object that is an iterator or an
-            iterable and yields instances of any type that is supported
-            by ``callback``. While this isn't required, it must be
-            provided before the application can be run.
-        callback (Optional[asyncio.coroutine]): A callable object that
-            takes two arguments, an instance of
-            :class:`doozer.base.Application` and the (possibly)
-            preprocessed incoming message.  While this isn't required,
-            it must be provided before the application can be run.
+        name: The name of the application.
+        settings: An object with attributed-based settings.
+        consumer: Any object that is an iterator or an iterable and
+            yields instances of any type that is supported by
+            ``callback``. While this isn't required, it must be provided
+            before the application can be run.
+        callback: A callable object that takes two arguments, an
+            instance of :class:`doozer.base.Application` and the
+            (possibly) preprocessed incoming message.  While this isn't
+            required, it must be provided before the application can be
+            run.
     """
 
-    def __init__(self, name, settings=None, *, consumer=None, callback=None):
+    def __init__(
+            self,
+            name: str,
+            settings: Optional[Any] = None,
+            *,
+            consumer: Optional[Consumer] = None,
+            callback: Optional[Callback] = None,
+    ) -> None:
         """Initialize the class."""
         self.name = name
 
@@ -46,7 +58,7 @@ class Application:
 
         # Callbacks
         self.callback = callback
-        self._callbacks = {
+        self._callbacks: Dict[str, List[Callback]] = {
             'error': [],
             'message_acknowledgement': [],
             'message_preprocessor': [],
@@ -55,7 +67,7 @@ class Application:
             'teardown': [],
         }
 
-        self.extensions = {}
+        self.extensions: Dict[str, 'extensions.Extension'] = {}
 
         self.consumer = consumer
 
@@ -67,19 +79,18 @@ class Application:
     def __repr__(self):
         return '<Application: {}>'.format(self)
 
-    def error(self, callback):
+    def error(self, callback: Callback) -> Callback:
         """Register an error callback.
 
         Args:
-            callback (asyncio.coroutine): A callable object that takes
-                three arguments: an instance of
-                :class:`doozer.base.Application`, the incoming message,
-                and the exception that was raised. It will be called any
-                time there is an exception while reading a message from
-                the queue.
+            callback: A callable object that takes three arguments: an
+                instance of :class:`doozer.base.Application`, the
+                incoming message, and the exception that was raised. It
+                will be called any time there is an exception while
+                reading a message from the queue.
 
         Returns:
-            asyncio.coroutine: The callback.
+            The callback.
 
         Raises:
             TypeError: If the callback isn't a coroutine.
@@ -87,18 +98,17 @@ class Application:
         self._register_callback(callback, 'error')
         return callback
 
-    def message_acknowledgement(self, callback):
+    def message_acknowledgement(self, callback: Callback) -> Callback:
         """Register a message acknowledgement callback.
 
         Args:
-            callback (asyncio.coroutine): A callable object that takes
-                two arguments: an instance of
-                :class:`doozer.base.Application` and the original
-                incoming message as its only argument. It will be called
-                once a message has been fully processed.
+            callback: A callable object that takes two arguments: an
+                instance of :class:`doozer.base.Application` and the
+                original incoming message as its only argument. It will
+                be called once a message has been fully processed.
 
         Returns:
-            asyncio.coroutine: The callback.
+            The callback.
 
         Raises:
             TypeError: If the callback isn't a coroutine.
@@ -106,18 +116,17 @@ class Application:
         self._register_callback(callback, 'message_acknowledgement')
         return callback
 
-    def message_preprocessor(self, callback):
+    def message_preprocessor(self, callback: Callback) -> Callback:
         """Register a message preprocessing callback.
 
         Args:
-            callback (asyncio.coroutine): A callable object that takes
-                two arguments: an instance of
-                :class:`doozer.base.Application` and the incoming
-                message. It will be called for each incoming message
-                with its result being passed to ``callback``.
+            callback: A callable object that takes two arguments: an
+                instance of :class:`doozer.base.Application` and the
+                incoming message. It will be called for each incoming
+                message with its result being passed to ``callback``.
 
         Returns:
-            asyncio.coroutine: The callback.
+            The callback.
 
         Raises:
             TypeError: If the callback isn't a coroutine.
@@ -125,18 +134,17 @@ class Application:
         self._register_callback(callback, 'message_preprocessor')
         return callback
 
-    def result_postprocessor(self, callback):
+    def result_postprocessor(self, callback: Callback) -> Callback:
         """Register a result postprocessing callback.
 
         Args:
-            callback (asyncio.coroutine): A callable object that takes
-                two arguments: an instance of
-                :class:`doozer.base.Application` and a result of
-                processing the incoming message. It will be called for
-                each result returned from ``callback``.
+            callback: A callable object that takes two arguments: an
+                instance of :class:`doozer.base.Application` and a
+                result of processing the incoming message. It will be
+                called for each result returned from ``callback``.
 
         Returns:
-            asyncio.coroutine: The callback.
+            The callback.
 
         Raises:
             TypeError: If the callback isn't a coroutine.
@@ -144,19 +152,23 @@ class Application:
         self._register_callback(callback, 'result_postprocessor')
         return callback
 
-    def run_forever(self, num_workers=1, loop=None, debug=False):
+    def run_forever(
+            self,
+            num_workers: int = 1,
+            loop: Optional[AbstractEventLoop] = None,
+            debug: bool = False,
+    ) -> NoReturn:
         """Consume from the consumer until interrupted.
 
         Args:
-            num_workers (Optional[int]): The number of asynchronous
-                tasks to use to process messages received through the
-                consumer.  Defaults to 1.
-            loop (Optional[asyncio.asyncio.BaseEventLoop]): An event
-                loop that, if provided, will be used for running the
-                application. If none is provided, the default event loop
-                will be used.
-            debug (Optional[bool]): Whether or not to run with debug
-                mode enabled. Defaults to True.
+            num_workers: The number of asynchronous tasks to use to
+                process messages received through the consumer.
+                Defaults to 1.
+            loop: An event loop that, if provided, will be used for
+                running the application. If none is provided, the
+                default event loop will be used.
+            debug: Whether or not to run with debug mode enabled.
+                Defaults to True.
 
         Raises:
             TypeError: If the consumer is None or the callback isn't a
@@ -226,8 +238,8 @@ class Application:
             # Run the loop until the consumer says to stop or message
             # processing fails.
             loop.run_until_complete(asyncio.gather(consumer, future))
-        except BaseException as e:
-            self.logger.error(e)
+        except BaseException:
+            self.logger.exception('loop.canceled')
         finally:
             # If something went wrong while processing the message,
             # cancel the consumer. This will alert the processors to
@@ -243,7 +255,7 @@ class Application:
             # tasks inside the future.
             exc = future.exception()
             if exc:
-                self.logger.error(exc)
+                self.logger.exception('tasks.erred', exc_info=exc)
 
             # Teardown
             tasks = [
@@ -258,17 +270,17 @@ class Application:
 
         self.logger.debug('application.stopped')
 
-    def startup(self, callback):
+    def startup(self, callback: Callback) -> Callback:
         """Register a startup callback.
 
         Args:
-            callback (asyncio.coroutine): A callable object that takes
-                an instance of :class:`~doozer.base.Application` as its
-                only argument. It will be called once when the
-                application first starts up.
+            callback: A callable object that takes an instance of
+                :class:`~doozer.base.Application` as its only argument.
+                It will be called once when the application first starts
+                up.
 
         Returns:
-            asyncio.coroutine: The callback.
+            The callback.
 
         Raises:
             TypeError: If the callback isn't a coroutine.
@@ -276,17 +288,17 @@ class Application:
         self._register_callback(callback, 'startup')
         return callback
 
-    def teardown(self, callback):
+    def teardown(self, callback: Callback) -> Callback:
         """Register a teardown callback.
 
         Args:
-            callback (asyncio.coroutine): A callable object that takes
-                an instance of :class:`~doozer.base.Application` as its
-                only argument. It will be called once when the
-                application is shutting down.
+            callback: A callable object that takes an instance of
+                :class:`~doozer.base.Application` as its only argument.
+                It will be called once when the application is shutting
+                down.
 
         Returns:
-            asyncio.coroutine: The callback.
+            The callback.
 
         Raises:
             TypeError: If the callback isn't a coroutine.
@@ -294,11 +306,11 @@ class Application:
         self._register_callback(callback, 'teardown')
         return callback
 
-    async def _abort(self, exc):
+    async def _abort(self, exc: Abort) -> None:
         """Log the aborted message.
 
         Args:
-            exc (doozer.exceptions.Abort): The exception to be logged.
+            exc: The exception to be logged.
         """
         tb = sys.exc_info()[-1]
         stack = traceback.extract_tb(tb, 1)[-1]
@@ -308,7 +320,11 @@ class Application:
             'aborted_by': stack,
         })
 
-    async def _apply_callbacks(self, callbacks, value):
+    async def _apply_callbacks(
+            self,
+            callbacks: List[Callback],
+            value: Message,
+    ) -> Any:
         """Apply callbacks to a set of arguments.
 
         The callbacks will be called in the order in which they are
@@ -327,16 +343,16 @@ class Application:
             value = await callback(self, value)
         return value
 
-    async def _consume(self, queue):
+    async def _consume(self, queue: Queue) -> None:
         """Read in incoming messages.
 
         Messages will be read from the consumer until it raises an
         :class:`~doozer.exceptions.Abort` exception.
 
         Args:
-            queue (asyncio.Queue): Any messages read in by the consumer
-                will be added to the queue to share them with any future
-                processing the messages.
+            queue: Any messages read in by the consumer will be added to
+                the queue to share them with any future processing the
+                messages.
         """
         while True:
             # Read messages and add them to the queue.
@@ -348,17 +364,19 @@ class Application:
             else:
                 await queue.put(value)
 
-    async def _process(self, future, queue, loop):
+    async def _process(
+            self,
+            future: Future,
+            queue: Queue,
+            loop: AbstractEventLoop,
+    ) -> None:
         """Process incoming messages.
 
         Args:
-            future (asyncio.Future): The future that, when done, will
-                indicate that the consumer is no longer receiving new
-                messages.
-            queue (asyncio.Queue): A queue containing incoming messages
-              to be processed.
-            loop (asyncio.asyncio.BaseEventLoop): The event loop used by
-                the application.
+            future: The future that, when done, will indicate that the
+                consumer is no longer receiving new messages.
+            queue: A queue containing incoming messages to be processed.
+            loop: The event loop used by the application.
         """
         while True:
             if queue.empty():
@@ -419,12 +437,11 @@ class Application:
                 del message
                 del original_message
 
-    async def _postprocess_results(self, results):
+    async def _postprocess_results(self, results: Iterable) -> None:
         """Postprocess the results.
 
         Args:
-            results (iterable): The results returned by processing the
-                message.
+            results: The results returned by processing the message.
         """
         if results is None:
             return
@@ -437,13 +454,17 @@ class Application:
             except Abort as e:
                 await self._abort(e)
 
-    def _register_callback(self, callback, callback_container):
+    def _register_callback(
+            self,
+            callback: Callback,
+            callback_container: str,
+    ) -> None:
         """Register a callback.
 
         Args:
-            callback (asyncio.coroutine): The callback to register.
-            callback_container (str): The name of the container onto
-                which to append the callback.
+            callback: The callback to register.
+            callback_container: The name of the container onto which to
+                append the callback.
 
         Raises:
             TypeError: If the callback isn't a coroutine.
@@ -458,7 +479,7 @@ class Application:
             'callback': callback.__qualname__,
         })
 
-    def _teardown(self, future, loop):
+    def _teardown(self, future: Future, loop: AbstractEventLoop) -> None:
         """Tear down the application."""
         tasks = [
             asyncio.async(callback(self), loop=loop) for callback in
@@ -467,7 +488,7 @@ class Application:
         loop.run_until_complete(future)
 
 
-def _new_event_loop():
+def _new_event_loop() -> AbstractEventLoop:
     """Return a new event loop.
 
     If `uvloop <https://uvloop.readthedocs.io>`_ is installed, its event
@@ -476,7 +497,7 @@ def _new_event_loop():
     setting the event loop policy.
 
     Returns:
-        asyncio.AbstractEventLoopPolicy: The new event loop.
+        The new event loop.
     """
     try:
         import uvloop

--- a/doozer/cli.py
+++ b/doozer/cli.py
@@ -11,6 +11,7 @@ import logging
 import os
 import sys
 from threading import Thread
+from typing import Any, Callable, Dict, Sequence, Tuple, no_type_check
 
 from argh import ArghParser, CommandError
 from argh.decorators import arg, expects_obj
@@ -23,8 +24,12 @@ from .base import Application, _new_event_loop
 __all__ = ('register_commands',)
 
 
-def register_commands(namespace, functions, namespace_kwargs=None,
-                      func_kwargs=None):
+def register_commands(
+        namespace: str,
+        functions: Sequence[Callable],
+        namespace_kwargs: Dict[str, Any] = None,
+        func_kwargs: Dict[str, Any] = None,
+) -> None:
     """Register commands with the doozer CLI.
 
     The signature of each function provided through ``functions`` will
@@ -37,11 +42,11 @@ def register_commands(namespace, functions, namespace_kwargs=None,
     command line.
 
     Args:
-        namespace (str): A name representing the group of commands. The
+        namespace: A name representing the group of commands. The
             namespace is required to access the commands being added.
-        functions (List[callable]): A list of callables that are used to
-            create subcommands. More details can be found in the
-            documentation for :func:`~argh.assembling.add_commands`.
+        functions: A list of callables that are used to create
+            subcommands. More details can be found in the documentation
+            for :func:`~argh.assembling.add_commands`.
 
     .. note::
 
@@ -172,11 +177,16 @@ def register_commands(namespace, functions, namespace_kwargs=None,
     )
 
 
-def run(application_path: 'the path to the application to run',
+# Rather than using type annotations, this provides CLI help
+# information. It will fail if type checked.
+@no_type_check
+def run(
+        application_path: 'the path to the application to run',
         reloader: 'reload the application on changes' = False,
         workers: 'the number of asynchronous tasks to run' = 1,
         debug: 'enable debug mode' = False,
-        **kwargs):
+        **kwargs,
+):
     """Import and run an application."""
     if kwargs['quiet']:
         # If quiet mode has been enabled, set the number of verbose
@@ -253,16 +263,16 @@ def main():
     return parser.dispatch()
 
 
-def _import_application(application_path):
+def _import_application(application_path: str) -> Tuple[str, Application]:
     """Return the imported application and the path to it.
 
     Args:
-        application_path (str): The path to use to import the
-            application. It should be in the form of ``PATH[:APP]``.
+        application_path: The path to use to import the application. It
+            should be in the form of ``PATH[:APP]``.
 
     Returns:
-        Tuple[str, doozer.base.Application]: A two-tuple containing the
-            import path and the imported application.
+        A two-tuple containing the import path and the imported
+            application.
     """
     # Add the present working directory to the import path so that
     # services can be found without installing them to site-packages

--- a/doozer/config.py
+++ b/doozer/config.py
@@ -1,24 +1,26 @@
 """A custom configuration."""
 
+from typing import Any, Mapping
+
 __all__ = ('Config',)
 
 
 class Config(dict):
     """Custom mapping used to extend and override an app's settings."""
 
-    def from_mapping(self, mapping):
+    def from_mapping(self, mapping: Mapping[str, Any]) -> None:
         """Convert a mapping into settings.
 
         Uppercase keys of the specified mapping will be used to extend
         and update the existing settings.
 
         Args:
-            mapping (dict): A mapping encapsulating settings.
+            mapping: A mapping encapsulating settings.
         """
         for key, value in mapping.items():
             self[key] = value
 
-    def from_object(self, obj):
+    def from_object(self, obj: object) -> None:
         """Convert an object into settings.
 
         Uppercase attributes of the specified object will be used to

--- a/doozer/contrib/retry/__init__.py
+++ b/doozer/contrib/retry/__init__.py
@@ -5,44 +5,48 @@ messages that fail to process.
 """
 
 import asyncio
+from numbers import Number
 import time
 
+from doozer.base import Application
 from doozer.exceptions import Abort
 from doozer.extensions import Extension
 
 __all__ = ('Retry', 'RetryableException')
 
 
-def _calculate_delay(delay, backoff, number_of_retries):
+def _calculate_delay(
+        delay: Number,
+        backoff: Number,
+        number_of_retries: int,
+) -> Number:
     """Return the time to wait before retrying.
 
     Args:
-        delay (numbers.Number): The base amount of time, in seconds, by
-            which to delay the retry.
-        backoff (numbers.Number): The factor by which each retry should
-            be extended.
-        number_of_retries (int): The number of retry attempts already
-            made.
+        delay: The base amount of time, in seconds, by which to delay
+            the retry.
+        backoff: The factor by which each retry should be extended.
+        number_of_retries: The number of retry attempts already made.
 
     Returns:
-        numbers.Number: The amount of time to wait.
+        The amount of time to wait.
     """
+    assert isinstance(backoff, (int, float))
+
     backoff_factor = backoff ** number_of_retries
     return delay * backoff_factor
 
 
-def _exceeded_threshold(number_of_retries, maximum_retries):
+def _exceeded_threshold(number_of_retries: int, maximum_retries: int) -> bool:
     """Return True if the number of retries has been exceeded.
 
     Args:
-        number_of_retries (int): The number of retry attempts made
-            already.
-        maximum_retries (int): The maximum number of retry attempts to
-            make.
+        number_of_retries: The number of retry attempts made already.
+        maximum_retries: The maximum number of retry attempts to make.
 
     Returns:
-        bool: True if the maximum number of retry attempts have already
-            been made.
+        True if the maximum number of retry attempts have already been
+            made.
     """
     if maximum_retries is None:
         # Retry forever.
@@ -51,25 +55,27 @@ def _exceeded_threshold(number_of_retries, maximum_retries):
     return number_of_retries >= maximum_retries
 
 
-def _exceeded_timeout(start_time, duration):
+def _exceeded_timeout(start_time: Number, duration: Number) -> bool:
     """Return True if the timeout has been exceeded.
 
     Args:
-        start_time (int): The timestamp of the first retry attempt.
-        duration (int): The total number of seconds to retry for.
+        start_time: The timestamp of the first retry attempt.
+        duration: The total number of seconds to retry for.
 
     Returns:
-        bool: True if the timeout has passed.
+        True if the timeout has passed.
     """
     if duration is None:
         # Retry forever.
         return False
 
+    assert isinstance(duration, (int, float))
+
     # Duration is in seconds, not milliseconds like start_time.
     return start_time + (duration * 1000) <= int(time.time())
 
 
-async def _retry(app, message, exc):
+async def _retry(app: Application, message: dict, exc: Exception) -> None:
     """Retry the message.
 
     An exception that is included as a retryable type will result in the
@@ -77,13 +83,12 @@ async def _retry(app, message, exc):
     been reached.
 
     Args:
-        app (doozer.base.Application): The current application.
-        message (dict): The message to be retried.
-        exc (Exception): The exception that caused processing the
-            message to fail.
+        app: The current application.
+        message: The message to be retried.
+        exc: The exception that caused processing the message to fail.
 
     Raises:
-        Abort: If the message is scheduled to be retried.
+        If the message is scheduled to be retried.
     """
     if not isinstance(exc, app.settings['RETRY_EXCEPTIONS']):
         # If the exception raised isn't retryable, return control so the
@@ -126,14 +131,14 @@ async def _retry(app, message, exc):
     raise Abort('message.retried', message)
 
 
-def _retry_info(message):
+def _retry_info(message: dict) -> dict:
     """Return the retry attempt information.
 
     Args:
-        message (dict): The message to be retried.
+        message: The message to be retried.
 
     Returns:
-        dict: The retry attempt information.
+        The retry attempt information.
     """
     info = message.get('_retry', {})
     info.setdefault('count', 0)
@@ -160,12 +165,11 @@ class Retry(Extension):
         'RETRY_CALLBACK',
     )
 
-    def init_app(self, app):
+    def init_app(self, app: Application) -> None:
         """Initialize an ``Application`` instance.
 
         Args:
-            app (doozer.base.Application): Application instance to be
-                initialized.
+            app: Application instance to be initialized.
 
         Raises:
             TypeError: If the callback isn't a coroutine.

--- a/doozer/contrib/sphinx/__init__.py
+++ b/doozer/contrib/sphinx/__init__.py
@@ -2,10 +2,13 @@
 
 from sphinxcontrib.autoprogram import AutoprogramDirective
 
+from doozer.base import Application
+from doozer.extensions import Extension
 
-def _import_extension(import_path):
+
+def _import_extension(import_path: str) -> Extension:
     module_name, extension_name = import_path.split(':', 1)
-    module = __import__(module_name, None, None, [extension_name])
+    module = __import__(module_name, fromlist=[extension_name])
     return getattr(module, extension_name)
 
 
@@ -28,7 +31,7 @@ class DoozerCLIDirective(AutoprogramDirective):
         command line extensions.
     """
 
-    def prepare_autoprogram(self):
+    def prepare_autoprogram(self) -> None:
         """Prepare the instance to be run through autoprogram."""
         # Tell autoprogram how to find the argument parser.
         self.arguments = 'doozer.cli:parser',
@@ -38,13 +41,13 @@ class DoozerCLIDirective(AutoprogramDirective):
         # Sphinx documentation.
         self.options.setdefault('prog', 'doozer --app APP_PATH')
 
-    def register_cli(self):
+    def register_cli(self) -> None:
         """Register the CLI."""
         import_path, = self.arguments
         extension = _import_extension(import_path)
         extension().register_cli()
 
-    def run(self):
+    def run(self) -> None:
         """Register the CLI and run autoprogram."""
         self.register_cli()
         self.prepare_autoprogram()
@@ -52,6 +55,6 @@ class DoozerCLIDirective(AutoprogramDirective):
         return super().run()
 
 
-def setup(app):
+def setup(app: Application) -> None:
     """Register the extension."""
     app.add_directive('doozercli', DoozerCLIDirective)

--- a/doozer/exceptions.py
+++ b/doozer/exceptions.py
@@ -1,5 +1,7 @@
 """Custom exceptions used by Doozer."""
 
+from .types import Message
+
 __all__ = ('Abort',)
 
 
@@ -15,13 +17,13 @@ class Abort(Exception):
     message will still be processed.
 
     Args:
-        reason (str): The reason the message is being aborted. It should
-            be in the form of "noun.verb" (e.g., "provider.ignored").
+        reason: The reason the message is being aborted. It should be in
+            the form of "noun.verb" (e.g., "provider.ignored").
         message: The message that is being aborted. Usually this will be
             the incoming message, but it can also be the result.
     """
 
-    def __init__(self, reason, message):
+    def __init__(self, reason: str, message: Message) -> None:
         """Initialize the class."""
         super().__init__(reason)
         self.message = message

--- a/doozer/extensions.py
+++ b/doozer/extensions.py
@@ -1,5 +1,11 @@
 """Extension base."""
 
+from typing import Iterable, Mapping, Optional
+
+# doozer.extensions.Extension is needed for a forward reference in an
+# annotation.
+from . import base  # NOQA: F401
+
 __all__ = ('Extension',)
 
 
@@ -12,7 +18,7 @@ class Extension:
             of settings to interact with a database.
     """
 
-    def __init__(self, app=None):
+    def __init__(self, app: Optional['base.Application'] = None) -> None:
         """Initialize an instance of the extension.
 
         If app is provided, init_app will also be called with the
@@ -21,8 +27,7 @@ class Extension:
         application is usable.
 
         Args:
-            app (Optional[doozer.base.Application]): An application
-                instance that will be initialized.
+            app: An application instance that will be initialized.
         """
         self._app = None
 
@@ -30,7 +35,7 @@ class Extension:
             self.init_app(app)
 
     @property
-    def DEFAULT_SETTINGS(self):  # NOQA
+    def DEFAULT_SETTINGS(self) -> Mapping:  # NOQA: N802
         """A ``dict`` of default settings for the extension.
 
         When a setting is not specified by the application instance and
@@ -41,7 +46,7 @@ class Extension:
         return {}
 
     @property
-    def REQUIRED_SETTINGS(self):  # NOQA
+    def REQUIRED_SETTINGS(self) -> Iterable:  # NOQA: N802
         """An ``iterable`` of required settings for the extension.
 
         When an extension has required settings that do not have default
@@ -52,7 +57,7 @@ class Extension:
         """
         return ()
 
-    def init_app(self, app):
+    def init_app(self, app: 'base.Application') -> None:
         """Initialize the application.
 
         In addition to associating the extension's default settings with
@@ -60,8 +65,7 @@ class Extension:
         required settings.
 
         Args:
-            app (doozer.base.Application): An application instance that
-                will be initialized.
+            app: An application instance that will be initialized.
         """
         for key, value in self.DEFAULT_SETTINGS.items():
             app.settings.setdefault(key, value)
@@ -84,7 +88,7 @@ class Extension:
         self._app.extensions[self.__class__.__name__.lower()] = self
 
     @property
-    def app(self):
+    def app(self) -> 'base.Application':
         """Return the registered app."""
         if not self._app:
             raise RuntimeError(

--- a/doozer/types.py
+++ b/doozer/types.py
@@ -1,0 +1,22 @@
+"""Custom types for static type analysis."""
+
+import asyncio
+from typing import Any, Awaitable, Callable
+
+from typing_extensions import Protocol, runtime
+
+__all__ = ('Callback', 'Consumer')
+
+
+Callback = Callable[..., Awaitable]
+
+Message = Any
+
+
+@runtime
+class Consumer(Protocol):
+    """An implementation of the Consumer Interface."""
+
+    @asyncio.coroutine
+    def read(self) -> Any:
+        """The read method of the Consumer Interface."""

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,6 +6,7 @@ atomic = true
 force_sort_within_sections = true
 include_trailing_comma = true
 known_first_party = doozer
+known_third_party = sphinxcontrib
 lines_after_types = 1
 multi_line_output = 3
 not_skip = __init__.py

--- a/tox.ini
+++ b/tox.ini
@@ -8,13 +8,18 @@ deps =
     pytest-asyncio<0.4.0
     pytest-capturelog
     sphinxcontrib-autoprogram
+    # TODO(dirn): Exclude this from 3.7.
+    typing-extensions
 commands =
     coverage run -m pytest --strict {posargs: tests}
     coverage report -m --include="doozer/*"
 
 [testenv:docs]
 basepython = python3.6
-deps = -rdocs-requirements.txt
+deps =
+    -rdocs-requirements.txt
+    # TODO(dirn): Remove this once this job uses 3.7.
+    typing-extensions
 commands =
     sphinx-build -W -b html -d {envtmpdir}/doctrees docs docs/_build/html
     doc8 --allow-long-titles README.rst docs/ --ignore-path docs/_build/
@@ -41,8 +46,11 @@ deps =
     flake8-comprehensions
     flake8-docstrings<1.1.0
     flake8-isort
+    flake8-mypy
     pep8-naming
     pydocstyle<2.0.0
+    # TODO(dirn): Remove this once this job uses 3.7.
+    typing-extensions
 commands =
     flake8 doozer
 


### PR DESCRIPTION
This will add type annotations to Doozer. mypy is being added to the
`pep8` tox job through flake8-mypy. A few custom types are being added
to a new `types` module to make sure that the correct types are being
passed around. Extension libraries can always use these types.

In addition to adding the annotations, a couple of changes are being
made to the code to address typing errors with code used by Doozer
(e.g., using `logging.exception` instead of `logging.error`).

It will also introduce the sphinx-autodoc-typehints plugin to include type
information in the docs.
