### PR TITLE
Drop support for Python 3.4 and 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,6 @@ language: python
 
 matrix:
   include:
-    - python: 3.4
-      env: TOX_ENV=py34
-    - python: 3.5
-      env: TOX_ENV=py35
     - python: 3.6
       env: TOX_ENV=py36
     - python: 3.6

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,8 @@ Version 1.3.0
 
 Release TBD
 
+- Drop support for Python 3.4 and 3.5 *(backwards incompatible)*
+
 Version 1.2.0
 -------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,4 +1,4 @@
-Version 1.3.0
+Version 2.0.0
 -------------
 
 Release TBD

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,13 +8,6 @@ the message received to a callback for processing. The messsage can be
 processed before handing it off to the callback, and the callback's results can
 be processed after they are returned to the application.
 
-.. note::
-
-    This documentation uses the ``async``/``await`` syntax introduced to Python
-    3.5 by way of `PEP 492 <https://www.python.org/dev/peps/pep-0492/>`_. If you
-    are using an older version of Python, replace ``async`` with the
-    ``@asyncio.coroutine`` decorator and ``await`` with ``yield from``.
-
 Installation
 ============
 

--- a/doozer/base.py
+++ b/doozer/base.py
@@ -294,8 +294,7 @@ class Application:
         self._register_callback(callback, 'teardown')
         return callback
 
-    @asyncio.coroutine
-    def _abort(self, exc):
+    async def _abort(self, exc):
         """Log the aborted message.
 
         Args:
@@ -309,8 +308,7 @@ class Application:
             'aborted_by': stack,
         })
 
-    @asyncio.coroutine
-    def _apply_callbacks(self, callbacks, value):
+    async def _apply_callbacks(self, callbacks, value):
         """Apply callbacks to a set of arguments.
 
         The callbacks will be called in the order in which they are
@@ -326,11 +324,10 @@ class Application:
             The return value of the final callback.
         """
         for callback in callbacks:
-            value = yield from callback(self, value)
+            value = await callback(self, value)
         return value
 
-    @asyncio.coroutine
-    def _consume(self, queue):
+    async def _consume(self, queue):
         """Read in incoming messages.
 
         Messages will be read from the consumer until it raises an
@@ -344,15 +341,14 @@ class Application:
         while True:
             # Read messages and add them to the queue.
             try:
-                value = yield from self.consumer.read()
+                value = await self.consumer.read()
             except Abort:
                 self.logger.debug('consumer.aborted')
                 return
             else:
-                yield from queue.put(value)
+                await queue.put(value)
 
-    @asyncio.coroutine
-    def _process(self, future, queue, loop):
+    async def _process(self, future, queue, loop):
         """Process incoming messages.
 
         Args:
@@ -373,23 +369,23 @@ class Application:
                 if future.done():
                     break
 
-                yield from asyncio.sleep(
+                await asyncio.sleep(
                     self.settings['SLEEP_TIME'], loop=loop)
                 continue
 
-            message = yield from queue.get()
+            message = await queue.get()
             # Save a copy of the original message in case its needed
             # later.
             original_message = deepcopy(message)
 
             try:
-                message = yield from self._apply_callbacks(
+                message = await self._apply_callbacks(
                     self._callbacks['message_preprocessor'], message)
                 self.logger.debug('message.preprocessed')
 
-                results = yield from self.callback(self, message)
+                results = await self.callback(self, message)
             except Abort as e:
-                yield from self._abort(e)
+                await self._abort(e)
             except Exception as e:
                 self.logger.error('message.failed', exc_info=sys.exc_info())
 
@@ -397,16 +393,16 @@ class Application:
                     # Any callback can prevent execution of further
                     # callbacks by raising Abort.
                     try:
-                        yield from callback(self, message, e)
+                        await callback(self, message, e)
                     except Abort:
                         break
             else:
-                yield from self._postprocess_results(results)
+                await self._postprocess_results(results)
             finally:
                 # Don't use _apply_callbacks here since we want to pass
                 # the original message into each callback.
                 for callback in self._callbacks['message_acknowledgement']:
-                    yield from callback(self, original_message)
+                    await callback(self, original_message)
                 self.logger.debug('message.acknowledged')
 
                 # If there are no new messages in the queue, _process
@@ -423,8 +419,7 @@ class Application:
                 del message
                 del original_message
 
-    @asyncio.coroutine
-    def _postprocess_results(self, results):
+    async def _postprocess_results(self, results):
         """Postprocess the results.
 
         Args:
@@ -436,11 +431,11 @@ class Application:
 
         for result in results:
             try:
-                yield from self._apply_callbacks(
+                await self._apply_callbacks(
                     self._callbacks['result_postprocessor'], result)
                 self.logger.debug('result.postprocessed')
             except Abort as e:
-                yield from self._abort(e)
+                await self._abort(e)
 
     def _register_callback(self, callback, callback_container):
         """Register a callback.

--- a/doozer/contrib/retry/__init__.py
+++ b/doozer/contrib/retry/__init__.py
@@ -69,8 +69,7 @@ def _exceeded_timeout(start_time, duration):
     return start_time + (duration * 1000) <= int(time.time())
 
 
-@asyncio.coroutine
-def _retry(app, message, exc):
+async def _retry(app, message, exc):
     """Retry the message.
 
     An exception that is included as a retryable type will result in the
@@ -115,12 +114,12 @@ def _retry(app, message, exc):
             backoff=app.settings['RETRY_BACKOFF'],
             number_of_retries=retry_info['count'],
         )
-        yield from asyncio.sleep(retry_info['delay'])
+        await asyncio.sleep(retry_info['delay'])
 
     # Update the retry information and retry the message.
     retry_info['count'] += 1
     message['_retry'] = retry_info
-    yield from app.settings['RETRY_CALLBACK'](app, message)
+    await app.settings['RETRY_CALLBACK'](app, message)
 
     # If the exception was retryable, none of the other callbacks should
     # execute.

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ def read(filename):
 
 setup(
     name='Doozer',
-    version='1.3.0',
+    version='2.0.0',
     author='Andy Dirnberger, Jon Banafato, and others',
     author_email='andy@dirnberger.me',
     url='https://doozer.readthedocs.io',

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setup(
     license='MIT',
     packages=find_packages(exclude=['tests']),
     zip_safe=False,
+    python_requires='>=3.6',
     install_requires=[
         # TODO: determine minimum versions for requirements
         'argh',
@@ -58,8 +59,6 @@ setup(
         'Natural Language :: English',
         'Operating System :: POSIX',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3 :: Only',
         'Topic :: Software Development :: Libraries :: Application Frameworks',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = docs,manifest,pep8,py34,py35,py36
+envlist = docs,manifest,pep8,py36
 
 [testenv]
 deps =


### PR DESCRIPTION
While both of these versions are still actively supported by the Python
Software Foundation, syntax and feature changes in 3.6 are compelling
enough to make the change. (There are some other backwards incompatible
changes in the works, so this is the best time to do this.)

We can take advantage of this to switch to using `async` and `await`.

Since these changes are not backwards compatible, the major version of
the next release needs to be incremented.