### PR TITLE
Use the latest Read the Docs build image

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,3 +1,6 @@
+build:
+  image: latest
+
 python:
   # Build the docs using the lowest supported version of Python.
   version: 3.6


### PR DESCRIPTION
This version of the build image is required for the version of Python
specified in 5edc45f.