### PR TITLE
Install Doozer with pip on Read the Docs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -2,5 +2,6 @@ build:
   image: latest
 
 python:
+  pip_install: true
   # Build the docs using the lowest supported version of Python.
   version: 3.6


### PR DESCRIPTION
Without installing the package, Sphinx's autodoc won't work.