### PR TITLE
Put all docs requirements in docs-requirements.txt

### DIFF
--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -3,3 +3,5 @@ sphinx>=1.3
 sphinx-autodoc-typehints
 sphinx_rtd_theme
 sphinxcontrib-autoprogram
+# TODO(dirn): Remove this once this job uses 3.7.
+typing-extensions

--- a/tox.ini
+++ b/tox.ini
@@ -16,10 +16,7 @@ commands =
 
 [testenv:docs]
 basepython = python3.6
-deps =
-    -rdocs-requirements.txt
-    # TODO(dirn): Remove this once this job uses 3.7.
-    typing-extensions
+deps = -rdocs-requirements.txt
 commands =
     sphinx-build -W -b html -d {envtmpdir}/doctrees docs docs/_build/html
     doc8 --allow-long-titles README.rst docs/ --ignore-path docs/_build/


### PR DESCRIPTION
typing-extensions was added to tox.ini in 13a0ad9. It should have been
added to docs-requirements.txt instead. This file is not only used by
the tox environment, but it's used by Read the Docs as well.