### PR TITLE
Better utilize the Read the Docs config file

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,3 +5,5 @@ python:
   pip_install: true
   # Build the docs using the lowest supported version of Python.
   version: 3.6
+
+requirements_file: docs-requirements.txt


### PR DESCRIPTION
I had envisioned this commit as being a much larger change, but it turns
out most of the settings used to generate Doozer's docs are the default.
The only setting support by the config file that doesn't use the default
(and wasn't already in the file) is `requirements_file`. While this is
currently set in the Read the Docs admin, having it set here will help
this file better serve as an example for other Doozer-related projects.