### PR TITLE
Clean up the tox configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,9 @@ matrix:
     - python: 3.6
       env: TOX_ENV=docs
     - python: 3.6
-      env: TOX_ENV=manifest
+      env: TOX_ENV=lint
     - python: 3.6
-      env: TOX_ENV=pep8
+      env: TOX_ENV=manifest
 
 install: pip install tox
 script: tox -e $TOX_ENV

--- a/doozer/contrib/sphinx/__init__.py
+++ b/doozer/contrib/sphinx/__init__.py
@@ -34,7 +34,7 @@ class DoozerCLIDirective(AutoprogramDirective):
     def prepare_autoprogram(self) -> None:
         """Prepare the instance to be run through autoprogram."""
         # Tell autoprogram how to find the argument parser.
-        self.arguments = 'doozer.cli:parser',
+        self.arguments = ('doozer.cli:parser',)
 
         # Most Doozer CLI extensions will be invoked the same way. The
         # extension authors shouldn't have to include that in their

--- a/doozer/extensions.py
+++ b/doozer/extensions.py
@@ -35,7 +35,7 @@ class Extension:
             self.init_app(app)
 
     @property
-    def DEFAULT_SETTINGS(self) -> Mapping:  # NOQA: N802
+    def DEFAULT_SETTINGS(self) -> Mapping:  # NOQA: D401,N802
         """A ``dict`` of default settings for the extension.
 
         When a setting is not specified by the application instance and
@@ -46,7 +46,7 @@ class Extension:
         return {}
 
     @property
-    def REQUIRED_SETTINGS(self) -> Iterable:  # NOQA: N802
+    def REQUIRED_SETTINGS(self) -> Iterable:  # NOQA: D401,N802
         """An ``iterable`` of required settings for the extension.
 
         When an extension has required settings that do not have default

--- a/doozer/types.py
+++ b/doozer/types.py
@@ -18,5 +18,5 @@ class Consumer(Protocol):
     """An implementation of the Consumer Interface."""
 
     @asyncio.coroutine
-    def read(self) -> Any:
+    def read(self) -> Any:  # NOQA: D401
         """The read method of the Consumer Interface."""

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [flake8]
-ignore = D105
+ignore = D105, D413
 
 [isort]
 atomic = true

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,9 @@
 [tox]
-envlist = docs,manifest,pep8,py36
+envlist = 
+    docs
+    manifest
+    lint
+    py36
 
 [testenv]
 deps =
@@ -16,40 +20,43 @@ commands =
 
 [testenv:docs]
 basepython = python3.6
-deps = -rdocs-requirements.txt
+deps = 
+    -rdocs-requirements.txt
 commands =
     sphinx-build -W -b html -d {envtmpdir}/doctrees docs docs/_build/html
     doc8 --allow-long-titles README.rst docs/ --ignore-path docs/_build/
 
-[testenv:isort]
+[testenv:format]
 basepython = python3.6
 # isort needs a full install to properly distinguish between first and
 # third party packages. This also means Sphinx needs to be installed for
 # doozer.contrib.sphinx.
 deps =
     isort
-commands = isort --recursive doozer
+commands = 
+    isort --recursive doozer
 
-[testenv:manifest]
-basepython = python3.6
-deps = check-manifest
-skip_install = true
-commands = check-manifest
-
-[testenv:pep8]
+[testenv:lint]
 basepython = python3.6
 deps =
     flake8-commas
     flake8-comprehensions
-    flake8-docstrings<1.1.0
+    flake8-docstrings
     flake8-isort
     flake8-mypy
     pep8-naming
-    pydocstyle<2.0.0
     # TODO(dirn): Remove this once this job uses 3.7.
     typing-extensions
 commands =
     flake8 doozer
+
+[testenv:manifest]
+basepython = python3.6
+deps = 
+    check-manifest
+skip_install = true
+commands = 
+    check-manifest
 
 [testenv:release]
 basepython = python3.6


### PR DESCRIPTION
This change has three primary focuses:

1. consistency: `deps` and `commands` will always appear on multiple
  lines.
2. naming: The `isort` and `pep8` environments will be renamed to more
  generic names, `format` and `lint`, that capture the spirit of what
  they do, not how they do it.
3. upgrades: The version requirements for flake8-docstrings and
  pydocstyle will be removed, allowing updated versions of them to be
  used.