### PR TITLE
Add support for Python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,11 @@ matrix:
   include:
     - python: 3.6
       env: TOX_ENV=py36
+    - python: 3.7
+      env: TOX_ENV=py37
+      dist: xenial
+      # TODO(dirn): Remove this once sudo is no longer required to use 3.7.
+      sudo: true
     - python: 3.6
       env: TOX_ENV=docs
     - python: 3.6

--- a/doozer/base.py
+++ b/doozer/base.py
@@ -192,7 +192,7 @@ class Application:
 
         # Start the application.
         tasks = [
-            asyncio.async(callback(self), loop=loop) for callback in
+            asyncio.ensure_future(callback(self), loop=loop) for callback in
             self._callbacks['startup']
         ]
         future = asyncio.gather(*tasks, loop=loop)
@@ -229,7 +229,10 @@ class Application:
         # running it should be restarted and wait until the future is
         # done.
         tasks = [
-            asyncio.async(self._process(consumer, queue, loop), loop=loop)
+            asyncio.ensure_future(
+                self._process(consumer, queue, loop),
+                loop=loop,
+            )
             for _ in range(num_workers)
         ]
         future = asyncio.gather(*tasks, loop=loop)
@@ -259,8 +262,9 @@ class Application:
 
             # Teardown
             tasks = [
-                asyncio.async(callback(self), loop=loop) for callback in
-                self._callbacks['teardown']
+                asyncio.ensure_future(callback(self), loop=loop)
+                for callback
+                in self._callbacks['teardown']
             ]
             future = asyncio.gather(*tasks, loop=loop)
             loop.run_until_complete(future)
@@ -482,7 +486,7 @@ class Application:
     def _teardown(self, future: Future, loop: AbstractEventLoop) -> None:
         """Tear down the application."""
         tasks = [
-            asyncio.async(callback(self), loop=loop) for callback in
+            asyncio.ensure_future(callback(self), loop=loop) for callback in
             self._callbacks['teardown']]
         future = asyncio.gather(*tasks, loop=loop)
         loop.run_until_complete(future)

--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,7 @@ setup(
         'Operating System :: POSIX',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3 :: Only',
         'Topic :: Software Development :: Libraries :: Application Frameworks',
     ]

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -40,7 +40,7 @@ def test_consume(event_loop, test_consumer):
 
     app = Application('testing', consumer=test_consumer)
 
-    asyncio.async(app._consume(queue))
+    asyncio.ensure_future(app._consume(queue), loop=event_loop)
 
     event_loop.stop()  # Run the event loop once.
     event_loop.run_forever()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -286,7 +286,7 @@ def test_run_forever(good_mock_service, cli_kwargs, caplog, capsys):
     """Test that run_forever is called on the imported app."""
     cli.run('good_import:app', **cli_kwargs)
     out, _ = capsys.readouterr()
-    assert 'Running <Application: testing> forever' in caplog.text()
+    assert 'Running <Application: testing> forever' in caplog.text
     assert 'Run, Forrest, run!' in out
 
 
@@ -294,5 +294,5 @@ def test_run_with_reloader(good_mock_service, cli_kwargs, caplog, capsys):
     """Test that an app is run with the reloader."""
     cli.run('good_import:app', reloader=True, **cli_kwargs)
     out, _ = capsys.readouterr()
-    assert 'Running <Application: testing> with reloader' in caplog.text()
+    assert 'Running <Application: testing> with reloader' in caplog.text
     assert 'Run, Forrest, run!' in out

--- a/tox.ini
+++ b/tox.ini
@@ -1,26 +1,26 @@
 [tox]
-envlist = 
+envlist =
     docs
     manifest
     lint
     py36
+    py37
 
 [testenv]
 deps =
     coverage
-    pytest<3.3
-    pytest-asyncio<0.4.0
-    pytest-capturelog
+    pytest
+    pytest-asyncio
     sphinxcontrib-autoprogram
-    # TODO(dirn): Exclude this from 3.7.
     typing-extensions
 commands =
     coverage run -m pytest --strict {posargs: tests}
     coverage report -m --include="doozer/*"
+passenv = PYTHONPATH
 
 [testenv:docs]
 basepython = python3.6
-deps = 
+deps =
     -rdocs-requirements.txt
 commands =
     sphinx-build -W -b html -d {envtmpdir}/doctrees docs docs/_build/html
@@ -33,7 +33,7 @@ basepython = python3.6
 # doozer.contrib.sphinx.
 deps =
     isort
-commands = 
+commands =
     isort --recursive doozer
 
 [testenv:lint]
@@ -45,21 +45,21 @@ deps =
     flake8-isort
     flake8-mypy
     pep8-naming
-    # TODO(dirn): Remove this once this job uses 3.7.
+    # TODO(dirn): Remove this once 3.7 is the minimum supported version.
     typing-extensions
 commands =
     flake8 doozer
 
 [testenv:manifest]
 basepython = python3.6
-deps = 
+deps =
     check-manifest
 skip_install = true
-commands = 
+commands =
     check-manifest
 
 [testenv:release]
-basepython = python3.6
+basepython = python3.7
 deps =
     twine
     wheel


### PR DESCRIPTION
In addition to adding a tox environment for testing with 3.7, 3.7 will
now be used for other environments such as `docs` and `lint`.