### PR TITLE
Remove runtime availability from the Consumer type

### DIFF
--- a/doozer/types.py
+++ b/doozer/types.py
@@ -3,7 +3,7 @@
 import asyncio
 from typing import Any, Awaitable, Callable
 
-from typing_extensions import Protocol, runtime
+from typing_extensions import Protocol
 
 __all__ = ('Callback', 'Consumer')
 
@@ -13,7 +13,6 @@ Callback = Callable[..., Awaitable]
 Message = Any
 
 
-@runtime
 class Consumer(Protocol):
     """An implementation of the Consumer Interface."""
 


### PR DESCRIPTION
The `runtime` decorator not needed by the `Consumer` type. The
decoration is being removed because it should only be included when
necessary.