### PR TITLE
Remove inaccurate comment

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -45,7 +45,6 @@ deps =
     flake8-isort
     flake8-mypy
     pep8-naming
-    # TODO(dirn): Remove this once 3.7 is the minimum supported version.
     typing-extensions
 commands =
     flake8 doozer tests


### PR DESCRIPTION
typing-extensions was not included in 3.7. Rather than writing an
uncertain comment about removing the dependency, the comment is being
removed.