### PR TITLE
Only run Python version-specific unit tests in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -100,8 +100,13 @@ jobs:
         run: |
           tox -e manifest
 
-  py36:
+  unit:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version:
+          - 3.6
+          - 3.7
 
     steps:
       - uses: actions/checkout@v2
@@ -111,13 +116,13 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.6
+          python-version: ${{ matrix.python-version }}
 
       - name: Cache dependencies
         uses: actions/cache@v2
         with:
           path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('test-requirements.txt') }}
+          key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('test-requirements.txt') }}
           restore-keys: |
             ${{ runner.os }}-pip-
 
@@ -129,35 +134,4 @@ jobs:
 
       - name: Run unit tests
         run: |
-          tox -e py36
-
-  py37:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 1
-
-      - name: Set up Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.7
-
-      - name: Cache dependencies
-        uses: actions/cache@v2
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('test-requirements.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
-
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r test-requirements.txt
-        if: steps.cache.outputs.cache-hit != 'true'
-
-      - name: Run unit tests
-        run: |
-          tox -e py37
+          tox -e unit

--- a/tox.ini
+++ b/tox.ini
@@ -3,20 +3,7 @@ envlist =
     docs
     manifest
     lint
-    py36
-    py37
-
-[testenv]
-deps =
-    coverage
-    pytest
-    pytest-asyncio
-    sphinxcontrib-autoprogram
-    typing-extensions
-commands =
-    coverage run -m pytest --strict {posargs: tests}
-    coverage report -m --include="doozer/*"
-passenv = PYTHONPATH
+    unit
 
 [testenv:docs]
 basepython = python3.6
@@ -81,3 +68,15 @@ deps =
 commands =
     python setup.py sdist bdist_wheel
     twine upload --sign --skip-existing {posargs} dist/*
+
+[testenv:unit]
+deps =
+    coverage
+    pytest
+    pytest-asyncio
+    sphinxcontrib-autoprogram
+    typing-extensions
+commands =
+    coverage run -m pytest --strict {posargs: tests}
+    coverage report -m --include="doozer/*"
+passenv = PYTHONPATH


### PR DESCRIPTION
To simplify running and maintaining the tests, [tox] will only run the
unit tests (now under the `unit` environment) using the version of
Python under which tox is installed. The tests will be run for all
supported versions of Python, though, as part of CI. To do this, the
version-specific [GitHub Actions] jobs are being reduced to a single job
using the matrix strategy.

[github actions]: https://docs.github.com/en/free-pro-team@latest/actions
[tox]: https://tox.readthedocs.io