### PR TITLE
Test more things with more Python versions in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,6 +9,11 @@ on:
 jobs:
   docs:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version:
+          - 3.6
+          - 3.7
 
     steps:
       - uses: actions/checkout@v2
@@ -18,13 +23,13 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.6
+          python-version: ${{ matrix.python-version }}
 
       - name: Cache dependencies
         uses: actions/cache@v2
         with:
           path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('test-requirements.txt') }}
+          key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('test-requirements.txt') }}
           restore-keys: |
             ${{ runner.os }}-pip-
 
@@ -40,6 +45,11 @@ jobs:
 
   lint:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version:
+          - 3.6
+          - 3.7
 
     steps:
       - uses: actions/checkout@v2
@@ -49,13 +59,13 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.6
+          python-version: ${{ matrix.python-version }}
 
       - name: Cache dependencies
         uses: actions/cache@v2
         with:
           path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('test-requirements.txt') }}
+          key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('test-requirements.txt') }}
           restore-keys: |
             ${{ runner.os }}-pip-
 

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,6 @@ envlist =
     unit
 
 [testenv:docs]
-basepython = python3.6
 deps =
     -rdocs-requirements.txt
 commands =
@@ -26,7 +25,6 @@ commands =
     black doozer tests
 
 [testenv:lint]
-basepython = python3.6
 deps =
     black==18.9b0
     # 3.6 seems to have introduced a change to how it handles forward


### PR DESCRIPTION
Historically only the unit tests have been run with all supported
versions of Python. The jobs to lint the code and to test that the
documentation builds were intentionally run using the minimum supported
version to ensure that new features of the language didn't creep into
the code. This left a hole in the coverage, though, as not all things
were tested using all supported versions of Python. By utilizing GitHub
Action's matrix strategy (just as was done in 6088490), we can address
this.

Note that the `manifest` job is being left as-is because it lints the
`MANIFEST.in` file, not the code itself (or anything about Python
directly).