### PR TITLE
Let environment control Python version in tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,6 @@ envlist =
     unit
 
 [testenv:docs]
-basepython = python3.6
 deps =
     -rdocs-requirements.txt
 commands =
@@ -14,7 +13,6 @@ commands =
     doc8 --allow-long-titles README.rst docs/ --ignore-path docs/_build/
 
 [testenv:format]
-basepython = python3.6
 # isort needs a full install to properly distinguish between first and
 # third party packages. This also means Sphinx needs to be installed for
 # doozer.contrib.sphinx.
@@ -26,7 +24,6 @@ commands =
     black doozer tests
 
 [testenv:lint]
-basepython = python3.6
 deps =
     black==18.9b0
     # 3.6 seems to have introduced a change to how it handles forward
@@ -53,7 +50,6 @@ commands =
     flake8 doozer tests
 
 [testenv:manifest]
-basepython = python3.6
 deps =
     check-manifest
 skip_install = true
@@ -61,7 +57,6 @@ commands =
     check-manifest
 
 [testenv:release]
-basepython = python3.7
 deps =
     twine
     wheel


### PR DESCRIPTION
Controlling the Python version is set in both the CI configuration and
the [tox] configuration. The former should be the source of truth as it
is the (testing) gatekeeper to getting a change merged. This can be
accomplished by removing the `basepython` value from tox environments
that set it.

For the environments that don't run under CI,  `format` and `release`,
`basepython` could have been left, but it's less important for the
latter and the former will soon have a [better way] of being handled.

[better way]: https://pre-commit.com
[tox]: https://tox.readthedocs.io