### PR TITLE
Use EditorConfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,27 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[.coveragerc]
+indent_size = 4
+indent_style = space
+
+[*.ini]
+indent_size = 4
+indent_style = space
+
+[*.py]
+indent_size = 4
+indent_style = space
+
+[*.rst]
+indent_size = 4
+indent_style = space
+
+[*.y{,a}ml]
+indent_size = 2
+indent_style = space

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,5 @@
 include LICENSE *.rst
+exclude .editorconfig
 
 # Tests
 include tox.ini .coveragerc conftest.py *-requirements.txt


### PR DESCRIPTION
Using [EditorConfig] makes it easier to have consistent styling across
contributors. While CI will change and block changes that don't conform
to some of the required style, the more that can be automated before
getting to CI, the easier it is for someone to contribute.

[editorconfig]: https://editorconfig.org