### PR TITLE
Use pre-commit for linting and fixing

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,23 +51,7 @@ jobs:
         with:
           python-version: 3.6
 
-      - name: Cache dependencies
-        uses: actions/cache@v2
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('test-requirements.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
-
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r test-requirements.txt
-        if: steps.cache.outputs.cache-hit != 'true'
-
-      - name: Run linters
-        run: |
-          tox -e lint
+      - uses: pre-commit/action@v2.0.0
 
   manifest:
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,38 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v3.3.0
+    hooks:
+      - id: check-merge-conflict
+      - id: check-yaml
+      - id: debug-statements
+      - id: end-of-file-fixer
+      - id: mixed-line-ending
+      - id: requirements-txt-fixer
+        files: requirements\.txt$
+      - id: trailing-whitespace
+  - repo: https://github.com/myint/autoflake
+    rev: v1.4
+    hooks:
+      - id: autoflake
+        args: ['--in-place', '--remove-all-unused-imports', '--remove-unused-variables']
+  - repo: https://github.com/PyCQA/isort
+    rev: 5.6.4
+    hooks:
+      - id: isort
+  - repo: https://github.com/psf/black
+    rev: 20.8b1
+    hooks:
+      - id: black
+        language_version: python3.6
+  - repo: https://gitlab.com/pycqa/flake8
+    rev: 3.8.4
+    hooks:
+      - id: flake8
+        additional_dependencies:
+          - flake8-bugbear
+          - flake8-docstrings
+          - flake8-mypy
+          - pep8-naming
+          - pydocstyle
+          # This is required for Python 3.6.
+          - typing-extensions

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,5 @@
 include LICENSE *.rst
-exclude .editorconfig
+exclude .editorconfig .pre-commit-config.yaml
 
 # Tests
 include tox.ini .coveragerc conftest.py *-requirements.txt

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,1 +1,2 @@
+pre-commit
 pytest<3.3

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -106,4 +106,3 @@ Indices and tables
 * :ref:`genindex`
 * :ref:`modindex`
 * :ref:`search`
-

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,6 @@
 envlist =
     docs
     manifest
-    lint
     unit
 
 [testenv:docs]
@@ -11,33 +10,6 @@ deps =
 commands =
     sphinx-build -W -b html -d {envtmpdir}/doctrees docs docs/_build/html
     doc8 --allow-long-titles README.rst docs/ --ignore-path docs/_build/
-
-[testenv:format]
-# isort needs a full install to properly distinguish between first and
-# third party packages. This also means Sphinx needs to be installed for
-# doozer.contrib.sphinx.
-deps =
-    black==20.8b1
-    isort==5.6.4
-commands =
-    isort --recursive .
-    black .
-
-[testenv:lint]
-deps =
-    black==20.8b1
-    flake8==3.8.4
-    flake8-bugbear==20.11.1
-    flake8-comprehensions==3.3.0
-    flake8-docstrings==1.5.0
-    flake8-mypy==17.8.0
-    isort==5.6.4
-    pep8-naming==0.11.1
-    pydocstyle==5.1.1
-    typing-extensions
-commands =
-    black --check .
-    flake8 .
 
 [testenv:manifest]
 deps =


### PR DESCRIPTION
[pre-commit] is a framework for managing pre-commit hooks. It will
allow us to replace some linting with fixing. It will also make it
easier for contributors to apply fixes before their code reaches CI.

[pre-commit]: https://pre-commit.com