### PR TITLE
Lint all Python files

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,9 +13,9 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import sys
 import os
-import shlex
+import sys
+
 import pkg_resources
 
 # If extensions (or modules to document with autodoc) are in another directory,
@@ -217,13 +217,13 @@ htmlhelp_basename = "Doozerdoc"
 
 latex_elements = {
     # The paper size ('letterpaper' or 'a4paper').
-    #'papersize': 'letterpaper',
+    # 'papersize': 'letterpaper',
     # The font size ('10pt', '11pt' or '12pt').
-    #'pointsize': '10pt',
+    # 'pointsize': '10pt',
     # Additional stuff for the LaTeX preamble.
-    #'preamble': '',
+    # 'preamble': '',
     # Latex figure (float) alignment
-    #'figure_align': 'htbp',
+    # 'figure_align': 'htbp',
 }
 
 # Grouping the document tree into LaTeX files. List of tuples

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,9 @@
 [flake8]
 ignore = D105, D202, D413, E203, E501
+per-file-ignores =
+    docs/conf.py: D100
+    docs/file_consumer.py: D100,D107,D403
+    setup.py: D100,D101,D102,D103,N812
 
 [isort]
 atomic = true

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
+import sys
+
 from setuptools import find_packages, setup
 from setuptools.command.test import test as TestCommand
-import sys
 
 
 class PyTest(TestCommand):

--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,7 @@ deps =
     black==20.8b1
     isort==5.6.4
 commands =
-    isort --recursive doozer tests
+    isort --recursive .
     black .
 
 [testenv:lint]
@@ -37,7 +37,7 @@ deps =
     typing-extensions
 commands =
     black --check .
-    flake8 doozer tests
+    flake8 .
 
 [testenv:manifest]
 deps =


### PR DESCRIPTION
Just as 11dc6ac did for [Black], this will do for [flake8]. All Python
files, not just the source and test files. [isort] will be applied to
the same files as well as it's checked by flake8-isort.

[black]: https://github.com/psf/black
[flake8]: https://gitlab.com/pycqa/flake8
[isort]: https://pycqa.github.io/isort/