### PR TITLE
Move type checks into a tox environment

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -84,6 +84,42 @@ jobs:
         run: |
           tox -e manifest
 
+  types:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version:
+          - 3.6
+          - 3.7
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 1
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Cache dependencies
+        uses: actions/cache@v2
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('test-requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r test-requirements.txt
+        if: steps.cache.outputs.cache-hit != 'true'
+
+      - name: Run type checks
+        run: |
+          tox -e types
+
   unit:
     runs-on: ubuntu-latest
     strategy:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,8 +31,5 @@ repos:
         additional_dependencies:
           - flake8-bugbear
           - flake8-docstrings
-          - flake8-mypy
           - pep8-naming
           - pydocstyle
-          # This is required for Python 3.6.
-          - typing-extensions

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,3 +13,6 @@ multi_line_output = 3
 
 [metadata]
 license_file = LICENSE
+
+[mypy]
+files = .

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,7 @@
 envlist =
     docs
     manifest
+    types
     unit
 
 [testenv:docs]
@@ -25,6 +26,15 @@ deps =
 commands =
     python setup.py sdist bdist_wheel
     twine upload --sign --skip-existing {posargs} dist/*
+
+[testenv:types]
+deps =
+    mypy==0.641
+    pytest
+    # This is required for Python 3.6.
+    typing-extensions
+commands =
+    mypy {posargs}
 
 [testenv:unit]
 deps =


### PR DESCRIPTION
[flake8-mypy] is no longer maintained. Rather than running [Mypy] as
part of a [pre-commit] hook, it will now be run as part of a [tox]
environment (`types`), which will be run by default when invoking `tox`.

[flake8-mypy]: https://github.com/ambv/flake8-mypy
[mypy]: http://www.mypy-lang.org
[pre-commit]: https://pre-commit.com