### PR TITLE
tell flake8 not to care about annotations

### DIFF
--- a/doozer/cli.py
+++ b/doozer/cli.py
@@ -177,7 +177,7 @@ def register_commands(
 # information. It will fail if type checked.
 
 
-@no_type_check  # NOQA: F722
+@no_type_check
 def run(
     application_path: "the path to the application to run",
     reloader: "reload the application on changes" = False,

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [flake8]
-ignore = D105, D202, D413, E203, E501
+ignore = D105, D202, D413, E203, E501, F722
 per-file-ignores =
     docs/conf.py: D100
     docs/file_consumer.py: D100,D107,D403


### PR DESCRIPTION
- Move type checks into a tox environment
- Support Python 3.8 and 3.9
- Tell flake8 to ignore type annotations
