### PR TITLE
Always use async def

### DIFF
--- a/doozer/types.py
+++ b/doozer/types.py
@@ -1,6 +1,5 @@
 """Custom types for static type analysis."""
 
-import asyncio
 from typing import Any, Awaitable, Callable
 
 from typing_extensions import Protocol
@@ -16,6 +15,5 @@ Message = Any
 class Consumer(Protocol):
     """An implementation of the Consumer Interface."""
 
-    @asyncio.coroutine
-    def read(self) -> Any:
+    async def read(self) -> Any:
         """The read method of the Consumer Interface."""  # NOQA: D401

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,8 +29,7 @@ class MockApplication(Application):
 class MockConsumer:
     """A stub consumer that can be used for testing."""
 
-    @asyncio.coroutine
-    def read(self):
+    async def read(self):
         """Return an item."""
         return 1
 
@@ -40,8 +39,7 @@ class MockAbortingConsumer:
 
     _run = False
 
-    @asyncio.coroutine
-    def read(self):
+    async def read(self):
         """Return an item."""
         if self._run:
             raise Abort("testing", {})
@@ -62,8 +60,7 @@ def cancelled_future(event_loop):
 def coroutine():
     """Return a coroutine function."""
 
-    @asyncio.coroutine
-    def _inner(*args, **kwargs):
+    async def _inner(*args, **kwargs):
         pass
 
     return _inner

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,7 +1,5 @@
 """Test Doozer's exceptions."""
 
-import asyncio
-
 from doozer import exceptions
 from doozer.base import Application
 
@@ -18,8 +16,7 @@ def test_abort_preprocessor(event_loop, cancelled_future, queue):
 
     queue.put_nowait({"a": 1})
 
-    @asyncio.coroutine
-    def callback(app, message):
+    async def callback(app, message):
         nonlocal callback_called
         callback_called = True
         return message
@@ -27,22 +24,19 @@ def test_abort_preprocessor(event_loop, cancelled_future, queue):
     app = Application("testing", callback=callback)
 
     @app.message_preprocessor
-    @asyncio.coroutine
-    def preprocess1(app, message):
+    async def preprocess1(app, message):
         nonlocal preprocess1_called
         preprocess1_called = True
         raise exceptions.Abort("testing", message)
 
     @app.message_preprocessor
-    @asyncio.coroutine
-    def preprocess2(app, message):
+    async def preprocess2(app, message):
         nonlocal preprocess2_called
         preprocess2_called = True
         return message
 
     @app.result_postprocessor
-    @asyncio.coroutine
-    def postprocess(app, result):
+    async def postprocess(app, result):
         nonlocal postprocess_called
         postprocess_called = True
         return result
@@ -65,8 +59,7 @@ def test_abort_callback(event_loop, cancelled_future, queue):
 
     queue.put_nowait({"a": 1})
 
-    @asyncio.coroutine
-    def callback(app, message):
+    async def callback(app, message):
         nonlocal callback_called
         callback_called = True
         raise exceptions.Abort("testing", message)
@@ -74,8 +67,7 @@ def test_abort_callback(event_loop, cancelled_future, queue):
     app = Application("testing", callback=callback)
 
     @app.result_postprocessor
-    @asyncio.coroutine
-    def postprocess(app, result):
+    async def postprocess(app, result):
         nonlocal postprocess_called
         postprocess_called = True
         return result
@@ -97,8 +89,7 @@ def test_abort_error(event_loop, cancelled_future, queue):
 
     queue.put_nowait({"a": 1})
 
-    @asyncio.coroutine
-    def callback(app, message):
+    async def callback(app, message):
         nonlocal callback_called
         callback_called = True
         raise TypeError("testing")
@@ -106,15 +97,13 @@ def test_abort_error(event_loop, cancelled_future, queue):
     app = Application("testing", callback=callback)
 
     @app.error
-    @asyncio.coroutine
-    def error1(app, message, exc):
+    async def error1(app, message, exc):
         nonlocal error1_called
         error1_called = True
         raise exceptions.Abort("testing", message)
 
     @app.error
-    @asyncio.coroutine
-    def error2(app, message, exc):
+    async def error2(app, message, exc):
         nonlocal error2_called
         error2_called = True
 
@@ -135,15 +124,13 @@ def test_abort_postprocess(event_loop, cancelled_future, queue):
 
     queue.put_nowait({"a": 1})
 
-    @asyncio.coroutine
-    def callback(app, message):
+    async def callback(app, message):
         return [True, False]
 
     app = Application("testing", callback=callback)
 
     @app.result_postprocessor
-    @asyncio.coroutine
-    def postprocess1(app, result):
+    async def postprocess1(app, result):
         nonlocal postprocess1_called_count
         postprocess1_called_count += 1
         if result:
@@ -152,8 +139,7 @@ def test_abort_postprocess(event_loop, cancelled_future, queue):
         return result
 
     @app.result_postprocessor
-    @asyncio.coroutine
-    def postprocess2(app, result):
+    async def postprocess2(app, result):
         nonlocal postprocess2_called_count
         postprocess2_called_count += 1
         return result


### PR DESCRIPTION
While most of the code has already been updated to use `async` and
`await`, a few references to the `asyncio.coroutine` remain. This will
replace them all with `async def`.
