### PR TITLE
Stop passing the loop into asyncio functions

### DIFF
--- a/doozer/base.py
+++ b/doozer/base.py
@@ -192,10 +192,10 @@ class Application:
 
         # Start the application.
         tasks = [
-            asyncio.ensure_future(callback(self), loop=loop)
+            asyncio.ensure_future(callback(self))
             for callback in self._callbacks["startup"]
         ]
-        future = asyncio.gather(*tasks, loop=loop)
+        future = asyncio.gather(*tasks)
         loop.run_until_complete(future)
 
         # The following debug mode checks are intentionally separate.
@@ -219,7 +219,7 @@ class Application:
         # Create an asynchronous queue to pass the messages from the
         # consumer to the processor. The queue should hold one message
         # for each processing task.
-        queue = asyncio.Queue(maxsize=num_workers, loop=loop)
+        queue = asyncio.Queue(maxsize=num_workers)
 
         # Create a task to monitor the consumer.
         consumer = loop.create_task(self._consume(queue))
@@ -229,10 +229,10 @@ class Application:
         # running it should be restarted and wait until the future is
         # done.
         tasks = [
-            asyncio.ensure_future(self._process(consumer, queue, loop), loop=loop)
+            asyncio.ensure_future(self._process(consumer, queue, loop))
             for _ in range(num_workers)
         ]
-        future = asyncio.gather(*tasks, loop=loop)
+        future = asyncio.gather(*tasks)
 
         try:
             # Run the loop until the consumer says to stop or message
@@ -259,10 +259,10 @@ class Application:
 
             # Teardown
             tasks = [
-                asyncio.ensure_future(callback(self), loop=loop)
+                asyncio.ensure_future(callback(self))
                 for callback in self._callbacks["teardown"]
             ]
-            future = asyncio.gather(*tasks, loop=loop)
+            future = asyncio.gather(*tasks)
             loop.run_until_complete(future)
 
             # Clean up after ourselves.
@@ -384,7 +384,7 @@ class Application:
                 if future.done():
                     break
 
-                await asyncio.sleep(self.settings["SLEEP_TIME"], loop=loop)
+                await asyncio.sleep(self.settings["SLEEP_TIME"])
                 continue
 
             message = await queue.get()
@@ -477,10 +477,10 @@ class Application:
     def _teardown(self, future: Future, loop: AbstractEventLoop) -> None:
         """Tear down the application."""
         tasks = [
-            asyncio.ensure_future(callback(self), loop=loop)
+            asyncio.ensure_future(callback(self))
             for callback in self._callbacks["teardown"]
         ]
-        future = asyncio.gather(*tasks, loop=loop)
+        future = asyncio.gather(*tasks)
         loop.run_until_complete(future)
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -51,7 +51,7 @@ class MockAbortingConsumer:
 @pytest.fixture
 def cancelled_future(event_loop):
     """Return a Future that's been cancelled."""
-    future = asyncio.Future(loop=event_loop)
+    future = asyncio.Future()
     future.cancel()
     return future
 

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -40,7 +40,7 @@ def test_consume(event_loop, test_consumer):
 
     app = Application("testing", consumer=test_consumer)
 
-    asyncio.ensure_future(app._consume(queue), loop=event_loop)
+    asyncio.ensure_future(app._consume(queue))
 
     event_loop.stop()  # Run the event loop once.
     event_loop.run_forever()


### PR DESCRIPTION
The `loop` argument to things such as `gather` and `Queue` is now
deprecated. This will remove it when calling them.
