### PR TITLE
Use the right version of Python to build the docs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -4,6 +4,6 @@ build:
 python:
   pip_install: true
   # Build the docs using the lowest supported version of Python.
-  version: 3.6
+  version: 3.8
 
 requirements_file: docs-requirements.txt


### PR DESCRIPTION
[Read the Docs][rtfd] needs to know which version of Python to use to
build the docs. This should have been set to 3.8 in b5c8489.

[rtfd]: https://readthedocs.org
