### PR TITLE
Use create_task instead of ensure_future

### DIFF
--- a/doozer/base.py
+++ b/doozer/base.py
@@ -192,8 +192,7 @@ class Application:
 
         # Start the application.
         tasks = [
-            asyncio.ensure_future(callback(self))
-            for callback in self._callbacks["startup"]
+            loop.create_task(callback(self)) for callback in self._callbacks["startup"]
         ]
         future = asyncio.gather(*tasks)
         loop.run_until_complete(future)
@@ -229,7 +228,7 @@ class Application:
         # running it should be restarted and wait until the future is
         # done.
         tasks = [
-            asyncio.ensure_future(self._process(consumer, queue, loop))
+            loop.create_task(self._process(consumer, queue, loop))
             for _ in range(num_workers)
         ]
         future = asyncio.gather(*tasks)
@@ -259,7 +258,7 @@ class Application:
 
             # Teardown
             tasks = [
-                asyncio.ensure_future(callback(self))
+                loop.create_task(callback(self))
                 for callback in self._callbacks["teardown"]
             ]
             future = asyncio.gather(*tasks)
@@ -477,7 +476,7 @@ class Application:
     def _teardown(self, future: Future, loop: AbstractEventLoop) -> None:
         """Tear down the application."""
         tasks = [
-            asyncio.ensure_future(callback(self))
+            asyncio.create_tasks(callback(self))
             for callback in self._callbacks["teardown"]
         ]
         future = asyncio.gather(*tasks)

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -40,7 +40,7 @@ def test_consume(event_loop, test_consumer):
 
     app = Application("testing", consumer=test_consumer)
 
-    asyncio.ensure_future(app._consume(queue))
+    event_loop.create_task(app._consume(queue))
 
     event_loop.stop()  # Run the event loop once.
     event_loop.run_forever()


### PR DESCRIPTION
`create_task` was added in Python 3.7 and `ensure_future` is now
deprecated. It will be removed in Python 3.10. As this project no longer
supports a version of Python without `create_task`, this is a good time
to switch to it.
