### PR TITLE
Update pytest args

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -34,6 +34,6 @@ deps =
     sphinxcontrib-autoprogram
     typing-extensions
 commands =
-    coverage run -m pytest --strict {posargs: tests}
+    coverage run -m pytest --strict-markers {posargs: tests}
     coverage report -m --include="doozer/*"
 passenv = PYTHONPATH


### PR DESCRIPTION
[pytest] has deprecated its `--strict` argument and replaced it with
`--strict-markers`. This will remove the deprecation warning from the
test output.

[pytest]: https://docs.pytest.org/en/stable/
