### PR TITLE
Postpone evaluation of annotations

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,6 +13,8 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
+from __future__ import annotations
+
 import os
 import sys
 

--- a/docs/file_consumer.py
+++ b/docs/file_consumer.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from doozer import Abort, Application
 
 

--- a/doozer/__init__.py
+++ b/doozer/__init__.py
@@ -1,4 +1,5 @@
 """Doozer."""
+from __future__ import annotations
 
 import os as _os
 

--- a/doozer/__main__.py
+++ b/doozer/__main__.py
@@ -1,4 +1,5 @@
 """Doozer package CLI entrypoint."""
+from __future__ import annotations
 
 import sys
 

--- a/doozer/base.py
+++ b/doozer/base.py
@@ -1,4 +1,5 @@
 """Implementation of the service."""
+from __future__ import annotations
 
 import asyncio
 from asyncio import AbstractEventLoop, Future, Queue
@@ -67,7 +68,7 @@ class Application:
             "teardown": [],
         }
 
-        self.extensions: Dict[str, "extensions.Extension"] = {}
+        self.extensions: Dict[str, extensions.Extension] = {}
 
         self.consumer = consumer
 

--- a/doozer/cli.py
+++ b/doozer/cli.py
@@ -1,5 +1,7 @@
 """Collection of Doozer CLI tasks."""
 
+from __future__ import annotations
+
 from argparse import Action
 from collections import Counter
 from contextlib import suppress

--- a/doozer/config.py
+++ b/doozer/config.py
@@ -1,4 +1,5 @@
 """A custom configuration."""
+from __future__ import annotations
 
 from typing import Any, Mapping
 

--- a/doozer/contrib/__init__.py
+++ b/doozer/contrib/__init__.py
@@ -1,1 +1,3 @@
 """Doozer's contrib packages."""
+
+from __future__ import annotations

--- a/doozer/contrib/retry/__init__.py
+++ b/doozer/contrib/retry/__init__.py
@@ -3,6 +3,7 @@
 Retry is a plugin to add the ability for Doozer to automatically retry
 messages that fail to process.
 """
+from __future__ import annotations
 
 import asyncio
 from numbers import Number

--- a/doozer/contrib/sphinx/__init__.py
+++ b/doozer/contrib/sphinx/__init__.py
@@ -1,4 +1,5 @@
 """Sphinx contrib plugin for documenting Doozer CLI extensions."""
+from __future__ import annotations
 
 from sphinxcontrib.autoprogram import AutoprogramDirective
 

--- a/doozer/exceptions.py
+++ b/doozer/exceptions.py
@@ -1,4 +1,5 @@
 """Custom exceptions used by Doozer."""
+from __future__ import annotations
 
 from .types import Message
 

--- a/doozer/extensions.py
+++ b/doozer/extensions.py
@@ -1,4 +1,5 @@
 """Extension base."""
+from __future__ import annotations
 
 from typing import Iterable, Mapping, Optional
 
@@ -18,7 +19,7 @@ class Extension:
             of settings to interact with a database.
     """
 
-    def __init__(self, app: Optional["base.Application"] = None) -> None:
+    def __init__(self, app: Optional[base.Application] = None) -> None:
         """Initialize an instance of the extension.
 
         If app is provided, init_app will also be called with the
@@ -57,7 +58,7 @@ class Extension:
         """  # NOQA: D401
         return ()
 
-    def init_app(self, app: "base.Application") -> None:
+    def init_app(self, app: base.Application) -> None:
         """Initialize the application.
 
         In addition to associating the extension's default settings with

--- a/doozer/types.py
+++ b/doozer/types.py
@@ -1,4 +1,5 @@
 """Custom types for static type analysis."""
+from __future__ import annotations
 
 from typing import Any, Awaitable, Callable
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,6 +6,7 @@ per-file-ignores =
     setup.py: D100,D101,D102,D103,N812
 
 [isort]
+add_imports = from __future__ import annotations
 atomic = true
 force_sort_within_sections = true
 include_trailing_comma = true

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import sys
 
 from setuptools import find_packages, setup

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 """Test configuration."""
+from __future__ import annotations
 
 import asyncio
 

--- a/tests/contrib/test_retry.py
+++ b/tests/contrib/test_retry.py
@@ -1,4 +1,5 @@
 """Test for doozer.contrib.retry."""
+from __future__ import annotations
 
 import asyncio
 from contextlib import suppress

--- a/tests/contrib/test_sphinx.py
+++ b/tests/contrib/test_sphinx.py
@@ -1,4 +1,5 @@
 """Tests for doozer.contrib.sphinx."""
+from __future__ import annotations
 
 from docutils.statemachine import StringList
 import pytest

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -1,4 +1,5 @@
 """Test Application."""
+from __future__ import annotations
 
 import asyncio
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,5 @@
 """CLI tests."""
+from __future__ import annotations
 
 from argparse import Namespace
 from inspect import getsource

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,4 +1,5 @@
 """Test the configuration utility."""
+from __future__ import annotations
 
 from doozer.config import Config
 

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,5 +1,7 @@
 """Test Doozer's exceptions."""
 
+from __future__ import annotations
+
 from doozer import exceptions
 from doozer.base import Application
 

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -1,4 +1,5 @@
 """Test handling of apps."""
+from __future__ import annotations
 
 import pytest
 

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1,4 +1,5 @@
 """Miscellaneous tests that don't have a better home."""
+from __future__ import annotations
 
 import asyncio
 import asyncio.base_events


### PR DESCRIPTION
[PEP 563] introduced a change to how annotations are evaluated. By
evaluating them later, forward references become easier to work with and
the cost of evaluating the annotations is no longer incurred at import
time. Because this behavior won't be the default until Python 3.10,
adding a `__future__` import to each Python module will enable it until
3.10 is the lowest supported version. [isort] has an option to
automatically add specified imports to any file it processes. This is
being turned on to automatically do this.

[isort]: https://pycqa.github.io/isort/
[pep 563]: https://www.python.org/dev/peps/pep-0563/
