### PR TITLE
Remove unnecessary NOQAs for forward references

### DIFF
--- a/doozer/base.py
+++ b/doozer/base.py
@@ -10,9 +10,7 @@ import sys
 import traceback
 from typing import Any, Dict, Iterable, List, NoReturn, Optional
 
-# doozer.extensions.Extension is needed for a forward reference in an
-# annotation.
-from . import extensions  # NOQA: F401
+from . import extensions
 from .config import Config
 from .exceptions import Abort
 from .types import Callback, Consumer, Message

--- a/doozer/extensions.py
+++ b/doozer/extensions.py
@@ -3,9 +3,7 @@ from __future__ import annotations
 
 from typing import Iterable, Mapping, Optional
 
-# doozer.extensions.Extension is needed for a forward reference in an
-# annotation.
-from . import base  # NOQA: F401
+from . import base
 
 __all__ = ("Extension",)
 


### PR DESCRIPTION
When the way annotations are evaluated changed in 39231e3, a handful of
`NOQA` comments became unnecessary as the imports were referenced in
code; previously they had been referenced in strings. The can now be
removed.
