### PR TITLE
Remove final references to typing_extensions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,5 +33,3 @@ repos:
           - flake8-mypy
           - pep8-naming
           - pydocstyle
-          # This is required for Python 3.6.
-          - typing-extensions

--- a/doozer/types.py
+++ b/doozer/types.py
@@ -1,9 +1,7 @@
 """Custom types for static type analysis."""
 from __future__ import annotations
 
-from typing import Any, Awaitable, Callable
-
-from typing_extensions import Protocol
+from typing import Any, Awaitable, Callable, Protocol
 
 __all__ = ("Callback", "Consumer")
 


### PR DESCRIPTION
Now that `Protocol` is included in the standard library
[typing-extensions] is no longer needed. This should have been removed
back in b5c8489 but was missed.

[typing-extensions]: https://pypi.org/p/typing-extensions
